### PR TITLE
Make WTHIT go to the correct page

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,7 +207,7 @@
 				</h4>
 			</div>
 			<div class="col-lg-3 col-md-6 mt-1 mt-md-4 mt-lg-0">
-				<a href="https://www.curseforge.com/minecraft/mc-mods/techreborn" target="_blank"><img src="img/lazyload-ph.png" data-src="https://media.forgecdn.net/avatars/thumbnails/337/208/64/64/637474424546110191.png" class="img-fluid img-protected mx-auto d-block img-13-style lazyload" alt="placeholder image" /></a>
+				<a href="https://www.curseforge.com/minecraft/mc-mods/wthit" target="_blank"><img src="img/lazyload-ph.png" data-src="https://media.forgecdn.net/avatars/thumbnails/337/208/64/64/637474424546110191.png" class="img-fluid img-protected mx-auto d-block img-13-style lazyload" alt="placeholder image" /></a>
 				<h4 class="mg-md text-lg-center text-center mx-auto d-block">
 					WTHIT
 				</h4>


### PR DESCRIPTION
Currently WTHIT goes to the Techreborn page on curseforge. Lets fix that!